### PR TITLE
feat: Add support to open Yandex.Music links with extension

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -41,6 +41,13 @@ app.on("ready", () => {
   });
 });
 
+app.setAsDefaultProtocolClient("yandex-music-app");
+
+app.on("open-url", (event, url) => {
+  event.preventDefault();
+  global.mainWindow.loadURL("https://music.yandex.ru/" + url.replace('yandex-music-app:/', ''));
+});
+
 exports.showLoader = () => {
   let view = new BrowserView();
   win.setBrowserView(view);


### PR DESCRIPTION
Привет! 

Я добавил базовую поддержку открытия ссылок из браузера.

Для этого я сделал расширение ([код](https://github.com/yangirov/yandex-music-app-linker)), которое редиректит ссылки Яндекс.Музыки в приложение.

Например, братан прислал ссылку вида https://music.yandex.ru/album/3277402/track/27373919.
Расширение средиректит по адресу "yandex-music-app:album/3277402/track/27373919" и откроет приложение на этой странице.

Что думаете? Возможно, можно как-то улучшить или сделать проще?