### PR TITLE
Probably a fix for deep link

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -62,7 +62,7 @@ app.setAsDefaultProtocolClient("yandex-music-app");
 
 app.on("open-url", (event, url) => {
   event.preventDefault();
-  global.mainWindow.loadURL("https://music.yandex.ru/" + url.replace('yandex-music-app:/', ''));
+  global.mainWindow.loadURL("https://music.yandex.ru/" + url.replace('yandex-music-app:', ''));
 });
 
 exports.showLoader = () => {


### PR DESCRIPTION
Есть ошибка в замене deep link на полноценную ссылку. Слэш здесь не требуется, т.к. в таком случае его обязательно придется указывать в тексте ссылки при переходе, что создает проблему, причина которой может не сразу быть заметна.
Скорректировал текст.

Для воспроизведения в последней релизной версии: введите `yandex-music-app:album/2276237/track/20148053` в браузере (обратите внимание, что первого слэша перед album здесь нет). Приложение должно перекинуть на трек, но вместо этого получится ошибка 404.